### PR TITLE
Unit test fix

### DIFF
--- a/epitest/environmentaltransmission_pytest.py
+++ b/epitest/environmentaltransmission_pytest.py
@@ -33,7 +33,7 @@ def environmental_transmission():
     Initialize the EnvironmentalTransmission object with specified parameters.
     Returns: Initialized EnvironmentalTransmission object/instance.
     """
-    return(EnvironmentalTransmission(beta=0.2/5, inf_col='InfState', trait_col='HH_Number'))
+    return(EnvironmentalTransmission(beta=0.2/5, inf_col='InfState'))
 
 def test_initialization(environmental_transmission):
     """
@@ -42,7 +42,6 @@ def test_initialization(environmental_transmission):
     """
     assert environmental_transmission.beta == 0.2/5
     assert environmental_transmission.inf_col == 'InfState'
-    assert environmental_transmission.trait_col == 'HH_Number'
     assert environmental_transmission.s_st == 'S'
     assert environmental_transmission.i_st == 'I'
     assert environmental_transmission.inf_to == 'I'
@@ -100,7 +99,6 @@ def test_to_yaml(environmental_transmission):
             'tabularepimdl.EnvironmentalTransmission': {
                 'beta': 0.2/5,
                 'inf_col': 'InfState',
-                'trait_col': 'HH_Number',
                 's_st': 'S',
                 'i_st': 'I',
                 'inf_to':'I',

--- a/epitest/epimodel_pytest.py
+++ b/epitest/epimodel_pytest.py
@@ -20,12 +20,15 @@ def init_state():
     """
     Create a dummy DataFrame to simulate the initial state of a population.
     Returns: DataFrame containing population counts, their infection states and age groups.
+
+    Column order matches what EpiModel.model_post_init produces (non-N/T columns sorted
+    alphabetically, followed by N then T).
     """
     init_state = {
-    'T': [0, 0],
-    'N': [100, 200],
+    'Age_Group': pd.Categorical(['youth', 'adult'], categories=['youth', 'adult']), #links to group_col of WAIFWTransmission, need to designate the order of categories
     'Infection_State': ['S', 'I'],
-    'Age_Group': pd.Categorical(['youth', 'adult'], categories=['youth', 'adult']) #links to group_col of WAIFWTransmission, need to designate the order of categories
+    'N': [100, 200],
+    'T': [0, 0],
     }
     return(pd.DataFrame(init_state))
     
@@ -248,16 +251,16 @@ def test_from_yaml(epimodel, epi_yaml, init_state, b_p, s_i, s_t, w_t):
     pd.testing.assert_frame_equal(returned_class_from_yaml.rules[0][0].start_state_sig, b_p.start_state_sig)
 
     #simple infection
-    assert returned_class_from_yaml.rules[1][0].column == s_i.column
-    assert returned_class_from_yaml.rules[1][0].stochastic == s_i.stochastic
-    
+    assert returned_class_from_yaml.rules[0][1].column == s_i.column
+    assert returned_class_from_yaml.rules[0][1].stochastic == s_i.stochastic
+
     #simple transition
-    assert returned_class_from_yaml.rules[2][0].from_st == s_t.from_st
-    assert returned_class_from_yaml.rules[2][0].rate == s_t.rate
+    assert returned_class_from_yaml.rules[0][2].from_st == s_t.from_st
+    assert returned_class_from_yaml.rules[0][2].rate == s_t.rate
 
     #waifw transmission
-    assert (returned_class_from_yaml.rules[3][0].waifw_matrix == w_t.waifw_matrix).all()
-    assert returned_class_from_yaml.rules[3][0].group_col == w_t.group_col
+    assert (returned_class_from_yaml.rules[0][3].waifw_matrix == w_t.waifw_matrix).all()
+    assert returned_class_from_yaml.rules[0][3].group_col == w_t.group_col
 
 def test_to_yaml(epimodel, init_state, epi_yaml):
     """

--- a/epitest/rule_pytest.py
+++ b/epitest/rule_pytest.py
@@ -8,16 +8,18 @@ import pytest
 import pandas as pd
 import numpy as np
 import yaml
+from pathlib import Path
 from my_module import MyRule
 
 @pytest.fixture
 def rule_yaml_setUp():
         """
-        Load a yaml file from local working directory.
+        Load a yaml file from the epitest directory (independent of the current working directory).
         Returns: content from the loaded yaml file.
         """
         # Load the YAML file
-        with open("yaml_input.yml", "r") as file:
+        yaml_path = Path(__file__).parent / "yaml_input.yml"
+        with open(yaml_path, "r") as file:
             rule_yaml = yaml.safe_load(file)
         return(rule_yaml)
         

--- a/tabularepimdl/EnvironmentalTransmission.py
+++ b/tabularepimdl/EnvironmentalTransmission.py
@@ -14,7 +14,6 @@ class EnvironmentalTransmission(Rule, BaseModel):
     '''!Initialization.
     @param beta: transmission risk if trait shared.
     @param inf_col: the column designating infection state.
-    @param trait_col: the column designaing the trait.
     @param s_st: the state for susceptibles, assumed to be S
     @param i_st: the state for infectious, assumed to be I
     @param inf_to: the state infectious folks go to, assumed to be I.
@@ -22,7 +21,6 @@ class EnvironmentalTransmission(Rule, BaseModel):
     '''
     beta: Annotated[int | float, Field(ge=0)]
     inf_col: str
-    #trait_col:str
     s_st: str = "S"
     i_st: str = "I"
     inf_to: str = "I"

--- a/tabularepimdl/MultiStrainInfectiousProcess.py
+++ b/tabularepimdl/MultiStrainInfectiousProcess.py
@@ -168,9 +168,9 @@ class MultiStrainInfectiousProcess(Rule, BaseModel):
                     toadd = toadd.assign(**{self.columns[j]: self.inf_to, "N": tmp[j]})
                     deltas = pd.concat([deltas, toadd])
             
-        #deltas = deltas[deltas["N"] != 0].reset_index(drop=True) #keep all rows with 0 for now, final code should remove 0 records
+        #deltas = deltas[deltas["N"] != 0] #keep all rows with 0 for now, final code should remove 0 records
         #print('multirule final delta is\n', deltas) #debug
-        return deltas
+        return deltas.reset_index(drop=True)
 
 
     def to_yaml(self) -> dict:


### PR DESCRIPTION
This PR resolves the following Pandas-structured unit test issues after re-organizing the package by PR #70 
* fix current working directory-dependent test failure in `rule_pytest.py`
* remove stale `trait_col` references in `environmentaltransmission_pytest.py` test
* fix stale `init_state` column order in `epimodel_pytest.py`
* fix missing index reset in `MultiStrainInfectiousProcess.get_deltas()`